### PR TITLE
Fix CI on master: Python packaging, Terraform fmt, correct branch triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [master]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,25 +8,31 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   python:
     name: Lint & test (Python)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
-      - name: Install dev dependencies
-        run: pip install pytest ruff
+      - name: Install package + dev dependencies
+        run: pip install -e ".[dev]"
 
       - name: Lint
-        run: ruff check ade/ tests/
+        run: ruff check .
 
       - name: Test
-        run: pytest tests/ -q
+        run: pytest
 
   terraform:
     name: Validate (Terraform)
@@ -35,7 +41,7 @@ jobs:
       run:
         working-directory: terraform
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: hashicorp/setup-terraform@v3
         with:
@@ -55,9 +61,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [python]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,9 +25,9 @@ jobs:
     name: Terraform plan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -65,7 +65,7 @@ jobs:
     # Protected environment => required reviewers gate production applies.
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy
 
 on:
   push:
-    branches: [main]
+    branches: [master]
     paths:
       - "ade/**"
       - "terraform/**"

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,9 @@ temp/
 # Testing
 .coverage
 htmlcov/
+# Terraform
+terraform/.terraform/
+*.tfstate
+*.tfstate.*
+*.tfplan
+tfplan

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
 .PHONY: test lint package clean
 
 test:
-	pytest tests/ -q
+	pytest
 
 lint:
-	ruff check ade/ tests/
+	ruff check .
 
 # Build the Lambda deployment zip consumed by Terraform (var.lambda_package_path).
+# Installs the package + runtime deps from pyproject.toml — one source of truth.
 package: clean
 	mkdir -p dist/build
-	pip install -r ade/requirements.txt -t dist/build --quiet
-	cp -r ade dist/build/ade
-	cd dist/build && zip -qr ../ade-lambda.zip . -x '*.pyc' -x '*__pycache__*'
+	pip install . -t dist/build --quiet
+	cd dist/build && zip -qr ../ade-lambda.zip . -x '*.pyc' -x '*__pycache__*' -x '*.dist-info/*'
 	@echo "Built dist/ade-lambda.zip"
 
 clean:

--- a/ade/agent/actions.py
+++ b/ade/agent/actions.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 import json
 import logging
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any
 
 from ade.config import Settings
 

--- a/ade/config.py
+++ b/ade/config.py
@@ -9,59 +9,59 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
+from typing import Any
 
 
-def _bool(name: str, default: bool) -> bool:
-    raw = os.environ.get(name)
-    if raw is None:
-        return default
-    return raw.strip().lower() in ("1", "true", "yes", "on")
+def _env(name: str, default: str = "") -> Any:
+    return field(default_factory=lambda: os.environ.get(name, default))
+
+
+def _env_int(name: str, default: int) -> Any:
+    return field(default_factory=lambda: int(os.environ.get(name, str(default))))
+
+
+def _env_bool(name: str, default: bool) -> Any:
+    def parse() -> bool:
+        raw = os.environ.get(name)
+        if raw is None:
+            return default
+        return raw.strip().lower() in ("1", "true", "yes", "on")
+
+    return field(default_factory=parse)
 
 
 @dataclass(frozen=True)
 class Settings:
     # Identity
-    project: str = field(default_factory=lambda: os.environ.get("ADE_PROJECT", "ade"))
-    environment: str = field(default_factory=lambda: os.environ.get("ADE_ENV", "dev"))
-    region: str = field(default_factory=lambda: os.environ.get("AWS_REGION", "us-east-1"))
+    project: str = _env("ADE_PROJECT", "ade")
+    environment: str = _env("ADE_ENV", "dev")
+    region: str = _env("AWS_REGION", "us-east-1")
 
     # Storage
-    data_lake_bucket: str = field(default_factory=lambda: os.environ.get("ADE_DATA_LAKE_BUCKET", ""))
-    artifacts_bucket: str = field(default_factory=lambda: os.environ.get("ADE_ARTIFACTS_BUCKET", ""))
-    docs_bucket: str = field(default_factory=lambda: os.environ.get("ADE_DOCS_BUCKET", ""))
-    state_table: str = field(default_factory=lambda: os.environ.get("ADE_STATE_TABLE", ""))
+    data_lake_bucket: str = _env("ADE_DATA_LAKE_BUCKET")
+    artifacts_bucket: str = _env("ADE_ARTIFACTS_BUCKET")
+    docs_bucket: str = _env("ADE_DOCS_BUCKET")
+    state_table: str = _env("ADE_STATE_TABLE")
 
     # Messaging / orchestration
-    alerts_topic_arn: str = field(default_factory=lambda: os.environ.get("ADE_ALERTS_TOPIC_ARN", ""))
-    approvals_topic_arn: str = field(default_factory=lambda: os.environ.get("ADE_APPROVALS_TOPIC_ARN", ""))
-    event_bus_name: str = field(default_factory=lambda: os.environ.get("ADE_EVENT_BUS", "default"))
-    etl_state_machine_arn: str = field(default_factory=lambda: os.environ.get("ADE_ETL_SFN_ARN", ""))
-    retrain_state_machine_arn: str = field(default_factory=lambda: os.environ.get("ADE_RETRAIN_SFN_ARN", ""))
+    alerts_topic_arn: str = _env("ADE_ALERTS_TOPIC_ARN")
+    approvals_topic_arn: str = _env("ADE_APPROVALS_TOPIC_ARN")
+    event_bus_name: str = _env("ADE_EVENT_BUS", "default")
+    etl_state_machine_arn: str = _env("ADE_ETL_SFN_ARN")
+    retrain_state_machine_arn: str = _env("ADE_RETRAIN_SFN_ARN")
 
     # LLM planner (Claude on Amazon Bedrock — note the `anthropic.` prefix)
-    planner_model: str = field(
-        default_factory=lambda: os.environ.get("ADE_PLANNER_MODEL", "anthropic.claude-opus-4-8")
-    )
-    planner_max_tokens: int = field(
-        default_factory=lambda: int(os.environ.get("ADE_PLANNER_MAX_TOKENS", "16000"))
-    )
+    planner_model: str = _env("ADE_PLANNER_MODEL", "anthropic.claude-opus-4-8")
+    planner_max_tokens: int = _env_int("ADE_PLANNER_MAX_TOKENS", 16000)
 
     # Guardrails
-    dry_run: bool = field(default_factory=lambda: _bool("ADE_DRY_RUN", True))
-    max_actions_per_plan: int = field(
-        default_factory=lambda: int(os.environ.get("ADE_MAX_ACTIONS_PER_PLAN", "5"))
-    )
-    max_remediation_attempts: int = field(
-        default_factory=lambda: int(os.environ.get("ADE_MAX_REMEDIATION_ATTEMPTS", "3"))
-    )
-    monthly_llm_budget_usd: float = field(
-        default_factory=lambda: float(os.environ.get("ADE_MONTHLY_LLM_BUDGET_USD", "200"))
-    )
+    dry_run: bool = _env_bool("ADE_DRY_RUN", True)
+    max_actions_per_plan: int = _env_int("ADE_MAX_ACTIONS_PER_PLAN", 5)
+    max_remediation_attempts: int = _env_int("ADE_MAX_REMEDIATION_ATTEMPTS", 3)
+    monthly_llm_budget_usd: int = _env_int("ADE_MONTHLY_LLM_BUDGET_USD", 200)
 
     # CloudWatch
-    metrics_namespace: str = field(
-        default_factory=lambda: os.environ.get("ADE_METRICS_NAMESPACE", "ADE")
-    )
+    metrics_namespace: str = _env("ADE_METRICS_NAMESPACE", "ADE")
 
 
 def load_settings() -> Settings:

--- a/ade/drift/data_drift.py
+++ b/ade/drift/data_drift.py
@@ -56,7 +56,7 @@ def population_stability_index(
     cur_dist = _histogram(current, edges)
     epsilon = 1e-4
     psi = 0.0
-    for b, c in zip(base_dist, cur_dist):
+    for b, c in zip(base_dist, cur_dist, strict=True):  # same edges -> same length
         b = max(b, epsilon)
         c = max(c, epsilon)
         psi += (c - b) * math.log(c / b)

--- a/ade/etl/pipeline_builder.py
+++ b/ade/etl/pipeline_builder.py
@@ -79,7 +79,9 @@ def compile_to_asl(spec: PipelineSpec, worker_lambda_arn: str) -> dict[str, Any]
     """Compile a PipelineSpec into a Step Functions state machine definition."""
     spec.validate()
 
-    def task(name: str, step: str, next_state: str | None, catch_to: str = "Quarantine") -> dict[str, Any]:
+    def task(
+        name: str, step: str, next_state: str | None, catch_to: str = "Quarantine"
+    ) -> dict[str, Any]:
         state: dict[str, Any] = {
             "Type": "Task",
             "Resource": worker_lambda_arn,

--- a/ade/etl/quality.py
+++ b/ade/etl/quality.py
@@ -107,33 +107,37 @@ def evaluate(rows: list[dict[str, Any]], rules: list[dict[str, Any]]) -> Quality
     return report
 
 
+def _violates(rule: dict[str, Any], value: Any) -> bool:
+    """True if a single value breaks a row-level rule."""
+    kind = rule.get("rule")
+    if kind == "not_null":
+        return not _present(value)
+    if not _present(value):
+        return False  # remaining rules only judge present values
+    if kind == "in_range":
+        try:
+            x = float(value)
+        except (TypeError, ValueError):
+            return True
+        lo, hi = rule.get("min"), rule.get("max")
+        return (lo is not None and x < lo) or (hi is not None and x > hi)
+    if kind == "matches":
+        return not re.search(rule.get("pattern", ""), str(value))
+    if kind == "allowed_values":
+        return value not in set(rule.get("values", []))
+    return False  # dataset-level rules (unique, row_count_min) aren't row-attributable
+
+
 def split_failing_rows(
     rows: list[dict[str, Any]], rules: list[dict[str, Any]]
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """Partition rows into (clean, quarantined) for row-level rules."""
-    quarantined_idx: set[int] = set()
-    for rule in rules:
-        kind = rule.get("rule")
-        column = rule.get("column", "")
-        for i, r in enumerate(rows):
-            v = r.get(column)
-            if kind == "not_null" and not _present(v):
-                quarantined_idx.add(i)
-            elif kind == "in_range" and _present(v):
-                try:
-                    x = float(v)
-                except (TypeError, ValueError):
-                    quarantined_idx.add(i)
-                    continue
-                lo, hi = rule.get("min"), rule.get("max")
-                if (lo is not None and x < lo) or (hi is not None and x > hi):
-                    quarantined_idx.add(i)
-            elif kind == "matches" and _present(v):
-                if not re.search(rule.get("pattern", ""), str(v)):
-                    quarantined_idx.add(i)
-            elif kind == "allowed_values" and _present(v):
-                if v not in set(rule.get("values", [])):
-                    quarantined_idx.add(i)
+    quarantined_idx = {
+        i
+        for rule in rules
+        for i, row in enumerate(rows)
+        if _violates(rule, row.get(rule.get("column", "")))
+    }
     clean = [r for i, r in enumerate(rows) if i not in quarantined_idx]
     quarantined = [r for i, r in enumerate(rows) if i in quarantined_idx]
     return clean, quarantined

--- a/ade/requirements.txt
+++ b/ade/requirements.txt
@@ -1,4 +1,0 @@
-# Runtime dependencies for the ADE Lambda package.
-# boto3/botocore are provided by the Lambda runtime; pinned here for local dev parity.
-anthropic[bedrock]>=0.92.0
-boto3>=1.34.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,48 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ade"
+version = "0.1.0"
+description = "Autonomous AI Data Engineer - event-driven agent for AWS data platforms"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "anthropic[bedrock]>=0.92.0",
+    "boto3>=1.34.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "ruff>=0.6",
+]
+
+[tool.setuptools.packages.find]
+include = ["ade*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]
+addopts = "-q"
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+src = ["ade", "tests"]
+extend-exclude = ["src", "notebooks", "experiments"]
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort
+    "UP",  # pyupgrade
+    "B",   # flake8-bugbear
+    "SIM", # flake8-simplify
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["SIM"]  # tests favour explicitness over simplification hints

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,10 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.70.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:LKnWZnujHcQPm3MAk4elP3H9VXNjlO6rNqlO5s330Yg=",
+  ]
+}

--- a/terraform/stepfunctions.tf
+++ b/terraform/stepfunctions.tf
@@ -111,9 +111,9 @@ resource "aws_sfn_state_machine" "retrain" {
             ChannelName = "train"
             DataSource = {
               S3DataSource = {
-                S3DataType                 = "S3Prefix"
-                "S3Uri.$"                  = "$.train_s3_uri"
-                S3DataDistributionType     = "FullyReplicated"
+                S3DataType             = "S3Prefix"
+                "S3Uri.$"              = "$.train_s3_uri"
+                S3DataDistributionType = "FullyReplicated"
               }
             }
           }]
@@ -137,8 +137,8 @@ resource "aws_sfn_state_machine" "retrain" {
         Next       = "PromotionGate"
       }
       PromotionGate = {
-        Type       = "Task"
-        Resource   = aws_lambda_function.ade["agent"].arn
+        Type     = "Task"
+        Resource = aws_lambda_function.ade["agent"].arn
         Parameters = {
           detail = {
             type           = "model_evaluated"
@@ -149,14 +149,14 @@ resource "aws_sfn_state_machine" "retrain" {
         End = true
       }
       NotifyFailure = {
-        Type       = "Task"
-        Resource   = aws_lambda_function.ade["agent"].arn
+        Type     = "Task"
+        Resource = aws_lambda_function.ade["agent"].arn
         Parameters = {
           detail = {
-            type           = "pipeline_failed"
-            "id.$"         = "$.job_name"
+            type            = "pipeline_failed"
+            "id.$"          = "$.job_name"
             "incident_id.$" = "$.job_name"
-            "error_text.$" = "States.JsonToString($.error)"
+            "error_text.$"  = "States.JsonToString($.error)"
           }
         }
         Next = "FailRetrain"

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
-    archive = {
-      source  = "hashicorp/archive"
-      version = "~> 2.4"
-    }
   }
 
   # Remote state — fill in and uncomment for team use.

--- a/tests/test_pipeline_builder.py
+++ b/tests/test_pipeline_builder.py
@@ -1,7 +1,6 @@
 import json
 
 import pytest
-
 from ade.etl.pipeline_builder import (
     PipelineSpec,
     PipelineSpecError,

--- a/tests/test_planner_and_orchestrator.py
+++ b/tests/test_planner_and_orchestrator.py
@@ -1,5 +1,4 @@
 import pytest
-
 from ade.agent.actions import ActionExecutor
 from ade.agent.memory import MemoryStore
 from ade.agent.orchestrator import Orchestrator
@@ -27,10 +26,9 @@ def settings(**overrides) -> Settings:
 
 
 def test_validate_rejects_unknown_action():
+    bad = {"name": "rm_rf_prod", "params": {}, "requires_approval": False}
     with pytest.raises(PlanValidationError):
-        validate_plan({"reasoning": "", "risk": "low",
-                       "actions": [{"name": "rm_rf_prod", "params": {}, "requires_approval": False}]},
-                      max_actions=5)
+        validate_plan({"reasoning": "", "risk": "low", "actions": [bad]}, max_actions=5)
 
 
 def test_validate_rejects_oversized_plan():


### PR DESCRIPTION
PR #3 merged before the CI fixes landed, so `master` currently has a red CI: the Python job fails to import `ade`, the Terraform job fails `fmt -check`, and both workflows trigger on a non-existent `main` branch. This PR brings the three fix commits onto `master`.

## What's fixed

**Python CI — `ModuleNotFoundError: No module named 'ade'`**
CI ran bare `pytest`, which doesn't put the repo root on `sys.path`. Added `pyproject.toml` making `ade` an installable package (single source of truth for deps, pytest, and ruff config); CI now runs `pip install -e ".[dev]"`. Removed the duplicate `ade/requirements.txt`.

**Terraform CI — `fmt -check` failed on `stepfunctions.tf`**
Reformatted. Verified `terraform fmt` + `init` + `validate` pass locally against AWS provider 5.70.0. Removed the unused `archive` provider and committed the provider lock file.

**Workflow triggers pointed at `main`, repo default is `master`**
Both `ci.yml` and `deploy.yml` now trigger on `master`. Added `workflow_dispatch` to CI.

## Hardening
- Stricter ruff ruleset (isort, pyupgrade, bugbear, simplify) — all findings fixed
- Bumped `checkout@v5` / `setup-python@v6` (Node 20 actions force-migrate June 16, 2026), pip caching, CI concurrency cancellation
- Lambda zip built from `pyproject.toml`; verified the packaged handler imports from inside the zip

All 43 tests pass; ruff + terraform checks clean. CI was verified green on this branch via run #2 (workflow_dispatch).

https://claude.ai/code/session_013qJoMkHEEiRGxnjRSq1zPU

---
_Generated by [Claude Code](https://claude.ai/code/session_013qJoMkHEEiRGxnjRSq1zPU)_